### PR TITLE
fix: building docker images from the compose

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Build Docker image
         uses: docker/build-push-action@v5
         with:
-          context: .
+          context: ./apps/api
           file: ./apps/api/Dockerfile
           push: false
           load: true
@@ -39,7 +39,7 @@ jobs:
       - name: Build Docker image
         uses: docker/build-push-action@v5
         with:
-          context: .
+          context: ./apps/puppeteer-service-ts/
           file: ./apps/puppeteer-service-ts/Dockerfile
           push: false
           load: true

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -6,8 +6,8 @@ WORKDIR /app
 # Install pnpm
 RUN npm install -g pnpm
 
-# Copy package files 
-COPY apps/api/package.json apps/api/pnpm-lock.yaml ./
+# Copy package files
+COPY ./package.json ./pnpm-lock.yaml ./
 
 # Install dependencies
 RUN pnpm install --frozen-lockfile
@@ -21,10 +21,10 @@ RUN apt-get update -qq && \
     && update-ca-certificates
 
 # Copy the rest of the application
-COPY apps/api ./
+COPY . ./
 
 # Build Go module
-COPY apps/api/src/lib/go-html-to-md ./src/lib/go-html-to-md
+COPY ./src/lib/go-html-to-md/ ./src/lib/go-html-to-md/
 RUN cd src/lib/go-html-to-md && \
     go mod tidy && \
     go build -o html-to-markdown.so -buildmode=c-shared html-to-markdown.go && \

--- a/apps/puppeteer-service-ts/Dockerfile
+++ b/apps/puppeteer-service-ts/Dockerfile
@@ -45,13 +45,13 @@ WORKDIR /app
 RUN npm install -g pnpm
 
 # Copy package files
-COPY apps/puppeteer-service-ts/package.json apps/puppeteer-service-ts/pnpm-lock.yaml ./
+COPY ./package.json ./pnpm-lock.yaml ./
 
 # Install dependencies
 RUN pnpm install --frozen-lockfile
 
 # Copy the rest of the application
-COPY apps/puppeteer-service-ts .
+COPY . .
 
 # Install Playwright with dependencies
 RUN npx playwright install --with-deps chromium

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,8 +19,11 @@ x-common-service: &common-service
     - "host.docker.internal:host-gateway"
 
 services:
-  playwright-service:
-    build: apps/playwright-service
+  puppeteer-service:
+    image: trieve/puppeteer-service-ts
+    build:
+      context: ./apps/puppeteer-service-ts/
+      dockerfile: Dockerfile
     environment:
       - PORT=3000
       - PROXY_SERVER=${PROXY_SERVER}
@@ -32,10 +35,11 @@ services:
       - backend
 
   api:
+    image: trieve/firecrawl
     <<: *common-service
     depends_on:
       - redis
-      - playwright-service
+      - puppeteer-service
     ports:
       - "3002:3002"
     command: ["pnpm", "run", "start:production"]
@@ -44,7 +48,7 @@ services:
     <<: *common-service
     depends_on:
       - redis
-      - playwright-service
+      - puppeteer-service
       - api
     command: ["pnpm", "run", "workers"]
 


### PR DESCRIPTION
Fixes Docker build context and resolves #19

This PR addresses two issues:
1. Resolves #19, add missing `playwright-service` folder, copied from firecrawl repo
2. Fixes the COPY error during `docker compose build` by aligning the Dockerfile path with the build context

The error was occurring because the Dockerfile and docker-compose build context were referencing different folder paths. This has been corrected and verified with successful curl tests.

Testing:
- Verified successful `docker compose build`
- Confirmed working with curl requests