### PR TITLE
feat: Add RAM and CPU limit variables to docker-compose to prevent connection issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ services:
       - TEST_API_KEY=${TEST_API_KEY}
       - HOST=${HOST:-0.0.0.0}
       - LOGGING_LEVEL=${LOGGING_LEVEL}
+      - MAX_RAM=${MAX_RAM:-0.95}
+      - MAX_CPU=${MAX_CPU:-0.95}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -93,6 +95,8 @@ services:
       - SCRAPING_BEE_API_KEY=${SCRAPING_BEE_API_KEY}
       - HOST=${HOST:-0.0.0.0}
       - LOGGING_LEVEL=${LOGGING_LEVEL}
+      - MAX_RAM=${MAX_RAM:-0.95}
+      - MAX_CPU=${MAX_CPU:-0.95}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,8 @@ x-common-service: &common-service
     - TEST_API_KEY=${TEST_API_KEY}
     - HOST=${HOST:-0.0.0.0}
     - LOGGING_LEVEL=${LOGGING_LEVEL}
+    - MAX_RAM=${MAX_RAM:-0.95}
+    - MAX_CPU=${MAX_CPU:-0.95}
   extra_hosts:
     - "host.docker.internal:host-gateway"
 


### PR DESCRIPTION
## Changes Made
- Added MAX_RAM and MAX_CPU environment variables to the common service configuration in docker-compose.yaml
- Default values set to 0.95 (95%) for both RAM and CPU usage

## Problem Solved
Previously, the services were experiencing "Can't accept connection" errors in docker-compose logs due to unmanaged resource allocation. These new environment variables help prevent resource exhaustion by limiting RAM and CPU usage to 95% by default.

## Benefits
- Prevents connection rejection issues
- Improves service stability
- Better resource management across containers
- Configurable limits through environment variables

## Testing Done
- Verified that services no longer show "Can't accept connection" errors in logs
- Tested with default values (0.95)
- Confirmed system stability under normal operation

## Notes
These changes address the connection issues reported in issues [#622](https://github.com/mendableai/firecrawl/issues/622) and [#660](https://github.com/mendableai/firecrawl/issues/660) by implementing resource constraints that prevent service overload.