### PR TITLE
fix(compose): force api build to avoid stale published image

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ Fire-engine, Firecrawl's solution for anti-bot pages, being closed source is the
 
 ## How to self host?
 
+> **Warning — published Docker images are currently stale.**
+> The `trieve/firecrawl` and `trieve/puppeteer-service-ts` images on Docker Hub were last published in September 2024 and no longer start because the bundled `corepack` predates npm's registry signing-key rotation (`Cannot find matching keyid`). There is no release-triggered publish workflow in this repo, so `:latest` and the pinned tags below have drifted.
+>
+> **To self-host today, build from source instead of pulling published images.** Clone this repo and run `docker compose up -d` from the repo root — the `docker-compose.yaml` is wired for local builds (the `api` service sets `pull_policy: build` so it always builds from `apps/api/Dockerfile` and never pulls). See [`SELF_HOST.md`](./SELF_HOST.md) for the full walkthrough. The snippet below will work as-is once the images are republished.
+
 You should add the following services to your docker-compose as follows. We trust that you can configure Kubernetes or other hosting solutions to run these services.
 
 ```yaml

--- a/SELF_HOST.md
+++ b/SELF_HOST.md
@@ -74,11 +74,19 @@ PLAYWRIGHT_MICROSERVICE_URL=  # set if you'd like to run a playwright fallback
         
     *   Don't forget to set the proxy server in your `.env` file as needed.
 
-4.  Build and run the Docker containers:
+4.  Build and run the Docker containers.
+
+    The `api` service in `docker-compose.yaml` sets `pull_policy: build`, so Compose builds it from `apps/api/Dockerfile` and never pulls the stale published `trieve/firecrawl:latest` image (see issue [#48](https://github.com/devflowinc/firecrawl-simple/issues/48)). `docker compose up -d` is enough:
     
     ```bash
+    docker compose up -d
+    ```
+
+    If you prefer, the explicit two-step form is equivalent:
+
+    ```bash
     docker compose build
-    docker compose up
+    docker compose up -d
     ```
 
 This will run a local instance of Firecrawl which can be accessed at `http://localhost:3002`.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,6 +38,7 @@ services:
   api:
     image: trieve/firecrawl
     <<: *common-service
+    pull_policy: build
     depends_on:
       - redis
       - puppeteer-service


### PR DESCRIPTION
## What & why

Fixes #48.

`docker compose up -d` on a fresh clone pulled the stale published `trieve/firecrawl:latest` image (built 2024-09-06) for the `api` service, which crashed on startup with `Cannot find matching keyid` because the bundled `corepack` predates npm's registry signing-key rotation. The `worker` service — which has no `image:` key — always built locally, so the two services ended up running different images, and `api` never came up. `docker compose build && docker compose up -d` worked because that path forces a local build.

Root cause: `docker-compose.yaml` declared both `image: trieve/firecrawl` and (via the `x-common-service` anchor) `build: apps/api` on the `api` service. With Compose's default `pull_policy`, `docker compose up` pulls the named image instead of building it.

## Changes

- **`docker-compose.yaml`** — add `pull_policy: build` to the `api` service. This keeps the `image:` key (which is still useful as the tag a future publish workflow would produce) but forces Compose to always build from `apps/api/Dockerfile` and never pull the registry artifact. The fix mirrors what the `worker` service already does implicitly (it has no `image:` key, so it only ever builds locally). Scope is intentionally limited to `api`; `puppeteer-service` has the same `image:` + `build:` pattern but is left untouched per the scoped fix — flagging it here as a known follow-up.
- **`README.md`** — the self-host snippet recommended pulling the pinned published images (`trieve/firecrawl:v0.0.46`, `trieve/puppeteer-service-ts:v0.0.6`), which are also stale and fail with the same corepack error. Added a prominent warning above the snippet explaining the images are stale, that there is no release-triggered publish workflow in this repo, and that the supported path today is to clone and run `docker compose up -d` from the repo root (which now uses `pull_policy: build`).
- **`SELF_HOST.md`** — updated step 4 to reflect that `docker compose up -d` is now sufficient (no separate `build` step needed) because the `api` service sets `pull_policy: build`, and linked to issue #48.

## Verification

`docker compose config` parses cleanly and renders `pull_policy: build` on the `api` service:

```text
  api:
    build:
      context: .../apps/api
      dockerfile: Dockerfile
    image: trieve/firecrawl
    pull_policy: build      # <-- now set
    ...
```

(Any `variable is not set` warnings are just because no `.env` file exists in this scratch checkout; they are pre-existing and unrelated.)

## Out of scope, but worth flagging

- **`puppeteer-service`** (`docker-compose.yaml:24`) has the same `image:` + `build:` trap. Left alone here per the scoped fix; happy to follow up.
- **`apps/puppeteer-service-ts/Dockerfile`** is malformed — two concatenated `FROM node:18-slim` stages (lines 1-21 and 22-70), so only the second stage takes effect. Probably worth a follow-up issue.
- **Two scheduled cron workflows are failing on every run.** `.github/workflows/check-queues.yml` (every 5 min) and `.github/workflows/clean-before-24h-complete-jobs.yml` (every 30 min) have been failing continuously — at least the last 24h, every single run. They curl `https://api.firecrawl.dev/admin/${BULL_AUTH_KEY}/...`, which suggests `BULL_AUTH_KEY` is not configured in the `devflowinc/firecrawl-simple` repo (or the endpoint has moved). This is unrelated to #48 but produces constant CI noise; the maintainers may want to either set the secret / update the endpoint, or archive these workflows (matching the existing `.github/archive/` pattern used for the SDK workflows).
- **No publish workflow exists.** `.github/workflows/build-docker-images.yml` only runs on PRs with `push: false` and `pr-<number>` tags — there is no release-triggered job to publish `trieve/firecrawl` to Docker Hub, which is why `:latest` and the pinned tags drifted in the first place. The `pull_policy: build` fix sidesteps this for self-hosters, but a publish workflow would be a cleaner long-term answer.

Closes #48.
